### PR TITLE
Strictly follow the RFC 6750 for the `Bearer` authentication scheme

### DIFF
--- a/Sources/OAuthenticator/Authenticator.swift
+++ b/Sources/OAuthenticator/Authenticator.swift
@@ -83,7 +83,7 @@ public final class Authenticator {
 		var authedRequest = request
 		let token = login.accessToken.value
 
-		authedRequest.setValue("bearer \(token)", forHTTPHeaderField: "Authorization")
+		authedRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
 		return try await urlLoader(authedRequest)
 	}

--- a/Tests/OAuthenticatorTests/AuthenticatorTests.swift
+++ b/Tests/OAuthenticatorTests/AuthenticatorTests.swift
@@ -27,7 +27,7 @@ final class AuthenticatorTests: XCTestCase {
 		let authedLoadExp = expectation(description: "load url")
 
 		let mockLoader: URLResponseProvider = { request in
-			XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "bearer TOKEN")
+			XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer TOKEN")
 			authedLoadExp.fulfill()
 
 			return ("hello".data(using: .utf8)!, URLResponse())
@@ -84,7 +84,7 @@ final class AuthenticatorTests: XCTestCase {
 		let authedLoadExp = expectation(description: "load url")
 
 		let mockLoader: URLResponseProvider = { request in
-			XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "bearer TOKEN")
+			XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer TOKEN")
 			authedLoadExp.fulfill()
 
 			return ("hello".data(using: .utf8)!, URLResponse())
@@ -118,7 +118,7 @@ final class AuthenticatorTests: XCTestCase {
 		let authedLoadExp = expectation(description: "load url")
 
 		let mockLoader: URLResponseProvider = { request in
-			XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "bearer REFRESHED")
+			XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer REFRESHED")
 			authedLoadExp.fulfill()
 
 			return ("hello".data(using: .utf8)!, URLResponse())


### PR DESCRIPTION
According to the RFC 6750, the client should use the `Bearer` authentication scheme to transmit the access token in the `Authorization` request header field: https://www.rfc-editor.org/rfc/rfc6750#section-2.1

Please note the uppercase `B`. This might not cause any issue with most servers but you probably want to strictly follow the RFC.