### PR TITLE
Use the name `authorization code`

### DIFF
--- a/Sources/OAuthenticator/Authenticator.swift
+++ b/Sources/OAuthenticator/Authenticator.swift
@@ -3,7 +3,7 @@ import AuthenticationServices
 
 public enum AuthenticatorError: Error {
 	case missingScheme
-	case missingLoginCode
+	case missingAuthorizationCode
 	case missingTokenURL
 	case missingAuthorizationURL
 	case refreshUnsupported

--- a/Sources/OAuthenticator/Services/GitHub.swift
+++ b/Sources/OAuthenticator/Services/GitHub.swift
@@ -69,7 +69,7 @@ public enum GitHub {
 	}
 
 	static func authenticationRequest(with url: URL, appCredentials: AppCredentials) throws -> URLRequest {
-		let code = try url.accessCode
+		let code = try url.authorizationCode
 
 		var urlBuilder = URLComponents()
 

--- a/Sources/OAuthenticator/URL+Code.swift
+++ b/Sources/OAuthenticator/URL+Code.swift
@@ -7,10 +7,10 @@ public extension URL {
 		return items?.compactMap { $0.value } ?? []
 	}
 
-	var accessCode: String {
+	var authorizationCode: String {
 		get throws {
 			guard let value = queryValues(named: "code").first else {
-				throw AuthenticatorError.missingLoginCode
+				throw AuthenticatorError.missingAuthorizationCode
 			}
 
 			return value


### PR DESCRIPTION
To avoid some confusion, I recommend to use the naming `authorization code` as defined in the RFC 6749:

- `missingLoginCode` -> `missingAuthorizationCode`
- `accessCode` -> `authorizationCode`

See https://www.rfc-editor.org/rfc/rfc6749#section-1.3.1