### PR TITLE
Add support for Google optional authorization parameters. 

### DIFF
--- a/Sources/OAuthenticator/Services/GoogleAPI.swift
+++ b/Sources/OAuthenticator/Services/GoogleAPI.swift
@@ -64,13 +64,18 @@ public struct GoogleAPI {
         public var includeGrantedScopes: Bool
         public var loginHint: String?
 
+        public init() {
+            self.includeGrantedScopes = true
+            self.loginHint = nil
+        }
+        
         public init(includeGrantedScopes: Bool, loginHint: String?) {
             self.includeGrantedScopes = includeGrantedScopes
             self.loginHint = loginHint
         }
     }
 
-    public static func googleAPITokenHandling(with parameters: GoogleAPIParameters) -> TokenHandling {
+    public static func googleAPITokenHandling(with parameters: GoogleAPIParameters = .init()) -> TokenHandling {
         TokenHandling(authorizationURLProvider: Self.authorizationURLProvider(with: parameters),
                       loginProvider: Self.loginProvider(),
                       refreshProvider: Self.refreshProvider())

--- a/Tests/OAuthenticatorTests/GoogleTests.swift
+++ b/Tests/OAuthenticatorTests/GoogleTests.swift
@@ -44,8 +44,12 @@ final class GoogleTests: XCTestCase {
         
         let creds = AppCredentials(clientId: "client_id", clientPassword: "client_pwd", scopes: ["scope1", "scope2"], callbackURL: callback!)
         let tokenHandling = GoogleAPI.googleAPITokenHandling(with: googleParameters)
-        let config = Authenticator.Configuration(appCredentials: creds, tokenHandling: tokenHandling)
-        
+        let config = Authenticator.Configuration(
+            appCredentials: creds,
+            tokenHandling: tokenHandling,
+            userAuthenticator: Authenticator.failingUserAuthenticator
+        )
+
         // Validate URL is properly constructed
         let googleURLProvider = try config.tokenHandling.authorizationURLProvider(creds)
         
@@ -72,8 +76,12 @@ final class GoogleTests: XCTestCase {
 
         let creds = AppCredentials(clientId: "client_id", clientPassword: "client_pwd", scopes: ["scope1", "scope2"], callbackURL: callback!)
         let tokenHandling = GoogleAPI.googleAPITokenHandling(with: googleParameters)
-        let config = Authenticator.Configuration(appCredentials: creds, tokenHandling: tokenHandling)
-        
+        let config = Authenticator.Configuration(
+            appCredentials: creds,
+            tokenHandling: tokenHandling,
+            userAuthenticator: Authenticator.failingUserAuthenticator
+        )
+
         // Validate URL is properly constructed
         let googleURLProvider = try config.tokenHandling.authorizationURLProvider(creds)
         


### PR DESCRIPTION
### Add support for Google optional parameters:

- `login_hint`: Suggest Google account email address to perform authorization with
- `include_granted_scopes`: Include previously granted scopes in the authorization request. 

### Fix
Remove unused parameters in the `LoginProvider` and `RefreshProvider`

### Tests
Add new tests to ensure `AuthorizationURL` is properly constructed