### PR TITLE
Send scopes to GitHub when authorizing

### DIFF
--- a/Sources/OAuthenticator/Services/GitHub.swift
+++ b/Sources/OAuthenticator/Services/GitHub.swift
@@ -82,6 +82,7 @@ public enum GitHub {
 			urlBuilder.queryItems = [
 				URLQueryItem(name: "client_id", value: credentials.clientId),
 				URLQueryItem(name: "redirect_uri", value: credentials.callbackURL.absoluteString),
+                URLQueryItem(name: "scope", value: credentials.scopeString),
 			]
 
 			if let state = parameters.state {


### PR DESCRIPTION
Without these, the client does not have the expected permissions.