### PR TITLE
Enable Authenticator.response(for:) to return a generic data type

### DIFF
--- a/Sources/OAuthenticator/Authenticator.swift
+++ b/Sources/OAuthenticator/Authenticator.swift
@@ -162,7 +162,7 @@ public actor Authenticator<UserDataType: Sendable> {
 }
 
 /// A default `URLSession`-backed `URLResponseProvider`.
-	@available(*, deprecated, message: "Please move to URLSession.defaultProvider")
+@available(*, deprecated, message: "Please move to URLSession.defaultProvider")
 @MainActor
 public let defaultAuthenticatorResponseProvider: URLResponseProvider = {
 	let session = URLSession(configuration: .default)

--- a/Sources/OAuthenticator/Models.swift
+++ b/Sources/OAuthenticator/Models.swift
@@ -5,6 +5,7 @@ import Foundation
 /// This is used to abstract the actual networking system from the underlying authentication
 /// mechanism.
 public typealias URLResponseProvider = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+public typealias URLUserDataProvider<UserDataType: Sendable> = @Sendable (URLRequest) async throws -> (UserDataType, URLResponse)
 
 public struct Token: Codable, Hashable, Sendable {
 	public let value: String
@@ -97,7 +98,7 @@ public struct TokenHandling {
 	public typealias AuthorizationURLProvider = @Sendable (AppCredentials) throws -> URL
 	public typealias LoginProvider = @Sendable (URL, AppCredentials, URL, URLResponseProvider) async throws -> Login
 	public typealias RefreshProvider = @Sendable (Login, AppCredentials, URLResponseProvider) async throws -> Login
-	public typealias ResponseStatusProvider = @Sendable ((Data, URLResponse)) throws -> ResponseStatus
+	public typealias ResponseStatusProvider = @Sendable ((any Sendable, URLResponse)) throws -> ResponseStatus
 
 	public let authorizationURLProvider: AuthorizationURLProvider
 	public let loginProvider: LoginProvider
@@ -115,12 +116,12 @@ public struct TokenHandling {
 	}
 
 	@Sendable
-	public static func allResponsesValid(result: (Data, URLResponse)) throws -> ResponseStatus {
+	public static func allResponsesValid<UserDataType: Sendable>(result: (UserDataType, URLResponse)) throws -> ResponseStatus {
 		return .valid
 	}
 
 	@Sendable
-	public static func refreshOrAuthorizeWhenUnauthorized(result: (Data, URLResponse)) throws -> ResponseStatus {
+	public static func refreshOrAuthorizeWhenUnauthorized<UserDataType: Sendable>(result: (UserDataType, URLResponse)) throws -> ResponseStatus {
 		guard let response = result.1 as? HTTPURLResponse else {
 			throw AuthenticatorError.httpResponseExpected
 		}

--- a/Tests/OAuthenticatorTests/AuthenticatorTests.swift
+++ b/Tests/OAuthenticatorTests/AuthenticatorTests.swift
@@ -101,7 +101,7 @@ final class AuthenticatorTests: XCTestCase {
 			storeTokenExp.fulfill()
 		}
 
-		let config = Authenticator.Configuration(
+		let config = Authenticator<Data>.Configuration(
 			appCredentials: Self.mockCredentials,
 			loginStorage: storage,
 //			loginStorage: nil,
@@ -148,10 +148,10 @@ final class AuthenticatorTests: XCTestCase {
 			XCTFail()
 		}
 
-		let config = Authenticator.Configuration(appCredentials: Self.mockCredentials,
-												 loginStorage: storage,
-												 tokenHandling: tokenHandling,
-												 userAuthenticator: Self.disabledUserAuthenticator)
+		let config = Authenticator<Data>.Configuration(appCredentials: Self.mockCredentials,
+													   loginStorage: storage,
+													   tokenHandling: tokenHandling,
+													   userAuthenticator: Self.disabledUserAuthenticator)
 
 		let auth = Authenticator(config: config, urlLoader: mockLoader)
 
@@ -200,10 +200,10 @@ final class AuthenticatorTests: XCTestCase {
 			XCTAssertEqual(login.accessToken.value, "REFRESHED")
 		}
 
-		let config = Authenticator.Configuration(appCredentials: Self.mockCredentials,
-												 loginStorage: storage,
-												 tokenHandling: tokenHandling,
-												 userAuthenticator: Self.disabledUserAuthenticator)
+		let config = Authenticator<Data>.Configuration(appCredentials: Self.mockCredentials,
+													   loginStorage: storage,
+													   tokenHandling: tokenHandling,
+													   userAuthenticator: Self.disabledUserAuthenticator)
 
 		let auth = Authenticator(config: config, urlLoader: mockLoader)
 
@@ -235,10 +235,10 @@ final class AuthenticatorTests: XCTestCase {
 			return URL(string: "my://login")!
 		}
 
-		let config = Authenticator.Configuration(appCredentials: Self.mockCredentials,
-												 tokenHandling: tokenHandling,
-												 mode: .manualOnly,
-												 userAuthenticator: mockUserAuthenticator)
+		let config = Authenticator<Data>.Configuration(appCredentials: Self.mockCredentials,
+													   tokenHandling: tokenHandling,
+													   mode: .manualOnly,
+													   userAuthenticator: mockUserAuthenticator)
 
 		let loadExp = expectation(description: "load url")
 		let mockLoader: URLResponseProvider = { request in
@@ -301,11 +301,11 @@ final class AuthenticatorTests: XCTestCase {
         }
         
         // Configure Authenticator with result callback
-        let config = Authenticator.Configuration(appCredentials: Self.mockCredentials,
-                                                 tokenHandling: tokenHandling,
-                                                 mode: .manualOnly,
-                                                 userAuthenticator: mockUserAuthenticator,
-                                                 authenticationStatusHandler: authenticationCallback)
+		let config = Authenticator<Data>.Configuration(appCredentials: Self.mockCredentials,
+													   tokenHandling: tokenHandling,
+													   mode: .manualOnly,
+													   userAuthenticator: mockUserAuthenticator,
+													   authenticationStatusHandler: authenticationCallback)
 
         let loadExp = expectation(description: "load url")
         let mockLoader: URLResponseProvider = { request in
@@ -357,11 +357,11 @@ final class AuthenticatorTests: XCTestCase {
         }
         
         // Configure Authenticator with result callback
-        let config = Authenticator.Configuration(appCredentials: Self.mockCredentials,
-                                                 tokenHandling: tokenHandling,
-                                                 mode: .manualOnly,
-                                                 userAuthenticator: Authenticator.failingUserAuthenticator,
-                                                 authenticationStatusHandler: authenticationCallback)
+		let config = Authenticator<Data>.Configuration(appCredentials: Self.mockCredentials,
+													   tokenHandling: tokenHandling,
+													   mode: .manualOnly,
+													   userAuthenticator: Authenticator<Data>.failingUserAuthenticator,
+													   authenticationStatusHandler: authenticationCallback)
         
         let auth = Authenticator(config: config, urlLoader: nil)
         do {
@@ -408,10 +408,10 @@ final class AuthenticatorTests: XCTestCase {
 			XCTAssertEqual(login.accessToken.value, "REFRESHED")
 		}
 
-		let config = Authenticator.Configuration(appCredentials: Self.mockCredentials,
-												 loginStorage: storage,
-												 tokenHandling: tokenHandling,
-												 userAuthenticator: Self.disabledUserAuthenticator)
+		let config = Authenticator<Data>.Configuration(appCredentials: Self.mockCredentials,
+													   loginStorage: storage,
+													   tokenHandling: tokenHandling,
+													   userAuthenticator: Self.disabledUserAuthenticator)
 
 		let auth = Authenticator(config: config, urlLoader: mockLoader.responseProvider)
 
@@ -468,10 +468,10 @@ final class AuthenticatorTests: XCTestCase {
             savedLogins.append(login)
         }
 
-        let config = Authenticator.Configuration(appCredentials: Self.mockCredentials,
-                                                 loginStorage: storage,
-                                                 tokenHandling: tokenHandling,
-                                                 userAuthenticator: Self.disabledUserAuthenticator)
+		let config = Authenticator<Data>.Configuration(appCredentials: Self.mockCredentials,
+													   loginStorage: storage,
+													   tokenHandling: tokenHandling,
+													   userAuthenticator: Self.disabledUserAuthenticator)
 
         let auth = Authenticator(config: config, urlLoader: mockLoader)
 

--- a/Tests/OAuthenticatorTests/GoogleTests.swift
+++ b/Tests/OAuthenticatorTests/GoogleTests.swift
@@ -44,10 +44,10 @@ final class GoogleTests: XCTestCase {
         
         let creds = AppCredentials(clientId: "client_id", clientPassword: "client_pwd", scopes: ["scope1", "scope2"], callbackURL: callback!)
         let tokenHandling = GoogleAPI.googleAPITokenHandling(with: googleParameters)
-        let config = Authenticator.Configuration(
+        let config = Authenticator<Data>.Configuration(
             appCredentials: creds,
             tokenHandling: tokenHandling,
-            userAuthenticator: Authenticator.failingUserAuthenticator
+            userAuthenticator: Authenticator<Data>.failingUserAuthenticator
         )
 
         // Validate URL is properly constructed
@@ -76,10 +76,10 @@ final class GoogleTests: XCTestCase {
 
         let creds = AppCredentials(clientId: "client_id", clientPassword: "client_pwd", scopes: ["scope1", "scope2"], callbackURL: callback!)
         let tokenHandling = GoogleAPI.googleAPITokenHandling(with: googleParameters)
-        let config = Authenticator.Configuration(
+        let config = Authenticator<Data>.Configuration(
             appCredentials: creds,
             tokenHandling: tokenHandling,
-            userAuthenticator: Authenticator.failingUserAuthenticator
+            userAuthenticator: Authenticator<Data>.failingUserAuthenticator
         )
 
         // Validate URL is properly constructed


### PR DESCRIPTION
First of all, I would like to thank you for providing this well-structured library. It is a joy to use. I use it primarily to control access to a medical records research server secured with OpenID Connect. These records are small, so the provided `Authenticator.response(for:)` method that returns a `Data` object is not a problem even for the limited memory on iPhones.

However, I now would like to use the library to access and transfer much larger data sets as well, and using `Data` as data-type to transfer a single entity is a problem. Streaming would be a much better choice (e.g. `AsyncBytes` or a file interface). To enable this, I tried to generalize the return type of `Authenticator.response(for:)` and created a proof-of-concept implementation. It works well, but I'm sure the implementation could be improved.

Would you be interested in adding a more generalized version of `Authenticator.response(for:)` to the library?

And an additional question: How would you go to provide a convenience interface for data uploading?