### PR TITLE
support an async JWTGenerator

### DIFF
--- a/Sources/OAuthenticator/Authenticator.swift
+++ b/Sources/OAuthenticator/Authenticator.swift
@@ -389,6 +389,7 @@ extension Authenticator {
 		let tokenHash = token.map { PKCEVerifier.computeHash($0) }
 
 		return try await self.dpop.response(
+			isolation: self,
 			for: request,
 			using: generator,
 			token: token,

--- a/Sources/OAuthenticator/Authenticator.swift
+++ b/Sources/OAuthenticator/Authenticator.swift
@@ -389,7 +389,6 @@ extension Authenticator {
 		let tokenHash = token.map { PKCEVerifier.computeHash($0) }
 
 		return try await self.dpop.response(
-			isolation: self,
 			for: request,
 			using: generator,
 			token: token,

--- a/Sources/OAuthenticator/DPoPSigner.swift
+++ b/Sources/OAuthenticator/DPoPSigner.swift
@@ -89,7 +89,7 @@ public enum DPoPError: Error {
 /// Currently only uses ES256.
 ///
 /// Details here: https://datatracker.ietf.org/doc/html/rfc9449
-public final class DPoPSigner {
+public final actor DPoPSigner {
 	public struct JWTParameters: Sendable, Hashable {
 		public let keyType: String
 
@@ -101,7 +101,7 @@ public final class DPoPSigner {
 	}
 	
 	public typealias NonceDecoder = (Data, URLResponse) throws -> String
-	public typealias JWTGenerator = @Sendable (JWTParameters) throws -> String
+	public typealias JWTGenerator = @Sendable (JWTParameters) async throws -> String
 	private let nonceDecoder: NonceDecoder
 	public var nonce: String?
 
@@ -126,7 +126,7 @@ extension DPoPSigner {
 		token: String?,
 		tokenHash: String?,
 		issuer: String?
-	) throws {
+	) async throws {
 		guard
 			let method = request.httpMethod,
 			let url = request.url
@@ -143,7 +143,7 @@ extension DPoPSigner {
 			issuingServer: issuer
 		)
 
-		let jwt = try jwtGenerator(params)
+		let jwt = try await jwtGenerator(params)
 
 		request.setValue(jwt, forHTTPHeaderField: "DPoP")
 
@@ -162,7 +162,6 @@ extension DPoPSigner {
 	}
 
 	public func response(
-		isolation: isolated (any Actor),
 		for request: URLRequest,
 		using jwtGenerator: JWTGenerator,
 		token: String?,
@@ -172,12 +171,12 @@ extension DPoPSigner {
 	) async throws -> (Data, URLResponse) {
 		var request = request
 
-		try authenticateRequest(&request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
+		try await authenticateRequest(&request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
 
 		let (data, response) = try await provider(request)
 
 		let existingNonce = nonce
-
+		
 		self.nonce = try nonceDecoder(data, response)
 
 		if nonce == existingNonce {
@@ -187,7 +186,7 @@ extension DPoPSigner {
 		print("DPoP nonce updated", existingNonce ?? "", nonce ?? "")
 
 		// repeat once, using newly-established nonce
-		try authenticateRequest(&request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
+		try await authenticateRequest(&request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
 
 		return try await provider(request)
 	}

--- a/Sources/OAuthenticator/DPoPSigner.swift
+++ b/Sources/OAuthenticator/DPoPSigner.swift
@@ -176,7 +176,7 @@ extension DPoPSigner {
 		let (data, response) = try await provider(request)
 
 		let existingNonce = nonce
-		
+
 		self.nonce = try nonceDecoder(data, response)
 
 		if nonce == existingNonce {

--- a/Sources/OAuthenticator/DPoPSigner.swift
+++ b/Sources/OAuthenticator/DPoPSigner.swift
@@ -121,8 +121,8 @@ public final class DPoPSigner {
 
 extension DPoPSigner {
 	public func authenticateRequest(
-		isolation: isolated (any Actor),
 		_ request: inout URLRequest,
+		isolation: isolated (any Actor),
 		using jwtGenerator: JWTGenerator,
 		token: String?,
 		tokenHash: String?,
@@ -173,7 +173,7 @@ extension DPoPSigner {
 	) async throws -> (Data, URLResponse) {
 		var request = request
 
-		try await authenticateRequest(isolation: isolation, &request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
+		try await authenticateRequest(&request, isolation: isolation, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
 
 		let (data, response) = try await provider(request)
 
@@ -188,7 +188,7 @@ extension DPoPSigner {
 		print("DPoP nonce updated", existingNonce ?? "", nonce ?? "")
 
 		// repeat once, using newly-established nonce
-		try await authenticateRequest(isolation: isolation, &request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
+		try await authenticateRequest(&request, isolation: isolation, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
 
 		return try await provider(request)
 	}

--- a/Sources/OAuthenticator/DPoPSigner.swift
+++ b/Sources/OAuthenticator/DPoPSigner.swift
@@ -121,6 +121,7 @@ public final class DPoPSigner {
 
 extension DPoPSigner {
 	public func authenticateRequest(
+		isolation: isolated (any Actor),
 		_ request: inout URLRequest,
 		using jwtGenerator: JWTGenerator,
 		token: String?,
@@ -172,7 +173,7 @@ extension DPoPSigner {
 	) async throws -> (Data, URLResponse) {
 		var request = request
 
-		try await authenticateRequest(&request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
+		try await authenticateRequest(isolation: isolation, &request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
 
 		let (data, response) = try await provider(request)
 
@@ -187,7 +188,7 @@ extension DPoPSigner {
 		print("DPoP nonce updated", existingNonce ?? "", nonce ?? "")
 
 		// repeat once, using newly-established nonce
-		try await authenticateRequest(&request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
+		try await authenticateRequest(isolation: isolation, &request, using: jwtGenerator, token: token, tokenHash: tokenHash, issuer: issuingServer)
 
 		return try await provider(request)
 	}

--- a/Sources/OAuthenticator/DPoPSigner.swift
+++ b/Sources/OAuthenticator/DPoPSigner.swift
@@ -89,7 +89,7 @@ public enum DPoPError: Error {
 /// Currently only uses ES256.
 ///
 /// Details here: https://datatracker.ietf.org/doc/html/rfc9449
-public final actor DPoPSigner {
+public final class DPoPSigner {
 	public struct JWTParameters: Sendable, Hashable {
 		public let keyType: String
 
@@ -162,6 +162,7 @@ extension DPoPSigner {
 	}
 
 	public func response(
+		isolation: isolated (any Actor),
 		for request: URLRequest,
 		using jwtGenerator: JWTGenerator,
 		token: String?,

--- a/Tests/OAuthenticatorTests/DPoPSignerTests.swift
+++ b/Tests/OAuthenticatorTests/DPoPSignerTests.swift
@@ -7,7 +7,7 @@ struct ExamplePayload: Codable, Hashable, Sendable {
 	let value: String
 }
 
- struct DPoPSignerTests {
+struct DPoPSignerTests {
     @Test
 	func basicSignature() async throws {
 		let signer = DPoPSigner()

--- a/Tests/OAuthenticatorTests/DPoPSignerTests.swift
+++ b/Tests/OAuthenticatorTests/DPoPSignerTests.swift
@@ -15,8 +15,8 @@ struct DPoPSignerTests {
 		var request = URLRequest(url: URL(string: "https://example.com")!)
 
 		try await signer.authenticateRequest(
-			isolation: MainActor.shared,
 			&request,
+			isolation: MainActor.shared,
 			using: { _ in "my_fake_jwt" },
 			token: "token",
 			tokenHash: "token_hash",

--- a/Tests/OAuthenticatorTests/DPoPSignerTests.swift
+++ b/Tests/OAuthenticatorTests/DPoPSignerTests.swift
@@ -9,12 +9,12 @@ struct ExamplePayload: Codable, Hashable, Sendable {
 
 struct DPoPSignerTests {
     @Test
-	func basicSignature() throws {
+	func basicSignature() async throws {
 		let signer = DPoPSigner()
 
 		var request = URLRequest(url: URL(string: "https://example.com")!)
 
-		try signer.authenticateRequest(
+		try await signer.authenticateRequest(
 			&request,
 			using: { _ in "my_fake_jwt" },
 			token: "token",

--- a/Tests/OAuthenticatorTests/DPoPSignerTests.swift
+++ b/Tests/OAuthenticatorTests/DPoPSignerTests.swift
@@ -7,7 +7,7 @@ struct ExamplePayload: Codable, Hashable, Sendable {
 	let value: String
 }
 
-struct DPoPSignerTests {
+ struct DPoPSignerTests {
     @Test
 	func basicSignature() async throws {
 		let signer = DPoPSigner()
@@ -15,6 +15,7 @@ struct DPoPSignerTests {
 		var request = URLRequest(url: URL(string: "https://example.com")!)
 
 		try await signer.authenticateRequest(
+			isolation: MainActor.shared,
 			&request,
 			using: { _ in "my_fake_jwt" },
 			token: "token",


### PR DESCRIPTION
You're the concurrency expert so if this is not the correct way to handle this I will not be insulted if you reject the PR.

I believe this is a breaking change.

I am using this package, https://github.com/vapor/jwt-kit
I have the following method,
```swift
private func generateJWT(params: DPoPSigner.JWTParameters) async throws -> String {
        let keys = JWTKeyCollection()
        
        // Generate ECDSA key pair for P-256
        let privateKey = ES256PrivateKey() // This generates a new P-256 key pair
        await keys.add(ecdsa: privateKey)
        
        // Create DPoP payload
        struct DPoPPayload: JWTPayload {
            let htm: String
            let htu: String
            let iat: IssuedAtClaim
            let jti: IDClaim
            let nonce: String?
            
            func verify(using key: some JWTAlgorithm) throws {
                // No additional verification needed
            }
        }
        
        let payload = DPoPPayload(
            htm: params.httpMethod,
            htu: params.requestEndpoint,
            iat: .init(value: .now),
            jti: .init(value: UUID().uuidString),
            nonce: params.nonce
        )
        
        // Sign with ES256 (ECDSA P-256)
        return try await keys.sign(payload)
    }
```

and I need this change to OAuthenticator so I can use this code,
```swift
let jwtGenerator: DPoPSigner.JWTGenerator = { params in
            // generate a P-256 signed token that uses `params` to match the specifications from
            // https://docs.bsky.app/docs/advanced-guides/oauth-client#dpop
            try await generateJWT(params: params)
        }
```