### PR TITLE
BlueSky refinements

### DIFF
--- a/Sources/OAuthenticator/DPoPSigner.swift
+++ b/Sources/OAuthenticator/DPoPSigner.swift
@@ -36,7 +36,7 @@ struct DPoPTokenPayload: Codable, Hashable, Sendable {
 	}
 }
 
-struct DPoPRequestPayload: Codable, Hashable, Sendable {
+public struct DPoPRequestPayload: Codable, Hashable, Sendable {
 	public let uniqueCode: String
 	public let httpMethod: String
 	public let httpRequestURL: String

--- a/Sources/OAuthenticator/DPoPSigner.swift
+++ b/Sources/OAuthenticator/DPoPSigner.swift
@@ -1,7 +1,7 @@
 #if canImport(CryptoKit)
 import Foundation
 
-struct DPoPTokenPayload: Codable, Hashable, Sendable {
+public struct DPoPTokenPayload: Codable, Hashable, Sendable {
 	public let uniqueCode: String
 	public let httpMethod: String
 	public let httpRequestURL: String

--- a/Sources/OAuthenticator/Models.swift
+++ b/Sources/OAuthenticator/Models.swift
@@ -30,14 +30,22 @@ public struct Token: Codable, Hashable, Sendable {
 public struct Login: Codable, Hashable, Sendable {
 	public var accessToken: Token
 	public var refreshToken: Token?
+	public var did: String?
 
     // User authorized scopes
     public var scopes: String?
 	public var issuingServer: String?
 
-    public init(accessToken: Token, refreshToken: Token? = nil, scopes: String? = nil, issuingServer: String? = nil) {
+	public init(
+		accessToken: Token,
+		refreshToken: Token? = nil,
+		did: String? = nil,
+		scopes: String? = nil,
+		issuingServer: String? = nil
+	) {
 		self.accessToken = accessToken
 		self.refreshToken = refreshToken
+		self.did = did
         self.scopes = scopes
 	}
 

--- a/Sources/OAuthenticator/Models.swift
+++ b/Sources/OAuthenticator/Models.swift
@@ -74,7 +74,7 @@ public struct AppCredentials: Codable, Hashable, Sendable {
 	}
 }
 
-public struct LoginStorage {
+public struct LoginStorage: Sendable {
 	public typealias RetrieveLogin = @Sendable () async throws -> Login?
 	public typealias StoreLogin = @Sendable (Login) async throws -> Void
 

--- a/Sources/OAuthenticator/Models.swift
+++ b/Sources/OAuthenticator/Models.swift
@@ -46,7 +46,8 @@ public struct Login: Codable, Hashable, Sendable {
 		self.accessToken = accessToken
 		self.refreshToken = refreshToken
 		self.did = did
-        self.scopes = scopes
+		self.scopes = scopes
+		self.issuingServer = issuingServer
 	}
 
 	public init(token: String, validUntilDate: Date? = nil) {

--- a/Sources/OAuthenticator/Services/Bluesky.swift
+++ b/Sources/OAuthenticator/Services/Bluesky.swift
@@ -44,6 +44,7 @@ public enum Bluesky {
 			Login(
 				accessToken: Token(value: access_token, expiresIn: expires_in),
 				refreshToken: refresh_token.map { Token(value: $0) },
+				did: sub,
 				scopes: scope,
 				issuingServer: issuingServer
 			)

--- a/Sources/OAuthenticator/Services/Bluesky.swift
+++ b/Sources/OAuthenticator/Services/Bluesky.swift
@@ -50,11 +50,15 @@ public enum Bluesky {
 		}
 	}
 
-	public static func tokenHandling(account: String, server: ServerMetadata, jwtGenerator: @escaping DPoPSigner.JWTGenerator) -> TokenHandling {
+	public static func tokenHandling(
+		account: String?,
+		server: ServerMetadata,
+		jwtGenerator: @escaping DPoPSigner.JWTGenerator
+	) -> TokenHandling {
 		TokenHandling(
 			parConfiguration: PARConfiguration(
 				url: URL(string: server.pushedAuthorizationRequestEndpoint)!,
-				parameters: ["login_hint": account]
+				parameters: { if let account { ["login_hint": account] } else { [:] } }()
 			),
 			authorizationURLProvider: authorizionURLProvider(server: server),
 			loginProvider: loginProvider(server: server),


### PR DESCRIPTION
Some refinements from our implementation of an end-to-end OAuth login prototype using Oauthenticate with BlueSky:

* make `login_hint` optional 838c856bafb952cbc7171635ccb122c3c7a3b0de
* mark `LoginStorage` as sendable bb25e225880b24c5c6a5a10463b56b6471d2c108
* pass the `did` field into the Login object ac5dc575a9caf5b65df61740734d90d22fa39898
* save `issuing_server` in in Login object 549c1f44fe677f5a64721e16e9ec89b900be6c60
* mark `DPoPRequestPayload` and `DPoPTokenPayload` as public 093350becfac175b66f1e456d979829f45f1f39a 07f257fbe4b4d58b96094a93b0e756c0d781b9f6

Let us know if these are useful or if you want them broken up into separate PR's