### PR TITLE
Add support for Protected Resource Metadata

### DIFF
--- a/Sources/OAuthenticator/Services/Bluesky.swift
+++ b/Sources/OAuthenticator/Services/Bluesky.swift
@@ -131,7 +131,7 @@ public enum Bluesky {
 			guard let tokenURL = URL(string: server.tokenEndpoint) else {
 				throw AuthenticatorError.missingTokenURL
 			}
-			
+
 			guard let verifier = params.pcke?.verifier else {
 				throw AuthenticatorError.pkceRequired
 			}
@@ -141,7 +141,7 @@ public enum Bluesky {
 				code_verifier: verifier,
 				redirect_uri: params.credentials.callbackURL.absoluteString,
 				grant_type: "authorization_code",
-				client_id: params.credentials.clientId // is this field truly necessary?
+				client_id: params.credentials.clientId
 			)
 
 			var request = URLRequest(url: tokenURL)
@@ -179,7 +179,7 @@ public enum Bluesky {
 				refresh_token: refreshToken,
 				redirect_uri: credentials.callbackURL.absoluteString,
 				grant_type: "refresh_token",
-				client_id: credentials.clientId // is this field truly necessary?
+				client_id: credentials.clientId
 			)
 
 			var request = URLRequest(url: tokenURL)
@@ -197,7 +197,7 @@ public enum Bluesky {
 			else {
 				print("data:", String(decoding: data, as: UTF8.self))
 				print("response:", response)
-				
+
 				throw AuthenticatorError.refreshNotPossible
 			}
 

--- a/Sources/OAuthenticator/WellknownEndpoints.swift
+++ b/Sources/OAuthenticator/WellknownEndpoints.swift
@@ -98,3 +98,64 @@ extension ClientMetadata {
 		)
 	}
 }
+
+// See: https://www.rfc-editor.org/rfc/rfc9728.html
+public struct ProtectedResourceMetadata: Codable, Hashable, Sendable {
+	public let resource: String
+	public let authorizationServers: [String]?
+	public let jwksUri: String?
+	public let scopesSupported: [String]?
+	public let bearerMethodsSupported: [String]?
+	public let resourceSigningAlgValuesSupported: [String]?
+	public let resourceName: String?
+	public let resourceDocumentation: String?
+	public let resourcePolicyUri: String?
+	public let resourceTosUri: String?
+	public let tlsClientCertificateBoundAccessTokens: Bool?
+	public let authorizationDetailsTypesSupported: [String]?
+	public let dpopSigningAlgValuesSupported: [String]?
+	public let dpopBoundAccessTokensRequired: Bool?
+	public let signedMetadata: String?
+
+	enum CodingKeys: String, CodingKey {
+		case resource
+		case authorizationServers = "authorization_servers"
+		case jwksUri = "jwks_uri"
+		case scopesSupported = "scopes_supported"
+		case bearerMethodsSupported = "bearer_methods_supported"
+		case resourceSigningAlgValuesSupported = "resource_signing_alg_values_supported"
+		case resourceName = "resource_name"
+		case resourceDocumentation = "resource_documentation"
+		case resourcePolicyUri = "resource_policy_uri"
+		case resourceTosUri = "resource_tos_uri"
+		case tlsClientCertificateBoundAccessTokens = "tls_client_certificate_bound_access_tokens"
+		case authorizationDetailsTypesSupported = "authorization_details_types_supported"
+		case dpopSigningAlgValuesSupported = "dpop_signing_alg_values_supported"
+		case dpopBoundAccessTokensRequired = "dpop_bound_access_tokens_required"
+		case signedMetadata = "signed_metadata"
+	}
+
+	public static func load(for host: String, provider: URLResponseProvider) async throws
+		-> ProtectedResourceMetadata
+	{
+		var components = URLComponents()
+		components.scheme = "https"
+		components.host = host
+		components.path = "/.well-known/oauth-protected-resource"
+
+		guard let url = components.url else {
+			throw MetadataError.urlInvalid
+		}
+
+		var request = URLRequest(url: url)
+		request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+		let (data, _) = try await provider(request)
+
+		return try self.loadJson(data: data)
+	}
+
+	public static func loadJson(data: Data) throws -> ProtectedResourceMetadata {
+		return try JSONDecoder().decode(ProtectedResourceMetadata.self, from: data)
+	}
+}

--- a/Tests/OAuthenticatorTests/WellKnownTests.swift
+++ b/Tests/OAuthenticatorTests/WellKnownTests.swift
@@ -3,6 +3,75 @@ import XCTest
 @testable import OAuthenticator
 
 final class WellKnownTests: XCTestCase {
+	func testServerMetadataLoad() async throws {
+		let loadUrlExp = expectation(description: "load url")
+
+		let mockLoader: URLResponseProvider = { request in
+			XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+			loadUrlExp.fulfill()
+
+			let content = """
+				{"issuer": "https://server-metadata.test", "authorization_endpoint": "https://server-metadata.test/oauth/authorize", "token_endpoint": "https://server-metadata.test/oauth/token"}
+				"""
+
+			let data = try XCTUnwrap(content.data(using: .utf8))
+
+			return (
+				data,
+				URLResponse(
+					url: request.url!,
+					mimeType: nil, expectedContentLength: data.count, textEncodingName: "utf-8")
+			)
+		}
+
+		let url = URL(string: "https://server-metadata.test/")!
+		let response = try await ServerMetadata.load(
+			for: url.host!,
+			provider: mockLoader
+		)
+
+		await fulfillment(of: [loadUrlExp], timeout: 1.0, enforceOrder: true)
+
+		XCTAssertEqual(response.issuer, "https://server-metadata.test")
+		XCTAssertEqual(response.authorizationEndpoint, "https://server-metadata.test/oauth/authorize")
+		XCTAssertEqual(response.tokenEndpoint, "https://server-metadata.test/oauth/token")
+	}
+
+	func testClientMetadataLoad() async throws {
+		let loadUrlExp = expectation(description: "load url")
+
+		let mockLoader: URLResponseProvider = { request in
+			XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+			loadUrlExp.fulfill()
+
+			let content = """
+				{"client_id": "https://client-metadata.test/oauth-client-metadata.json", "scope": "atproto", "redirect_uris": ["https://client-metadata.test/oauth/callback"]}
+				"""
+
+			let data = try XCTUnwrap(content.data(using: .utf8))
+
+			return (
+				data,
+				URLResponse(
+					url: request.url!,
+					mimeType: nil, expectedContentLength: data.count, textEncodingName: "utf-8")
+			)
+		}
+
+		let url = URL(string: "https://client-metadata.test/oauth-client-metadata.json")!
+		let response = try await ClientMetadata.load(
+			for: url.absoluteString,
+			provider: mockLoader
+		)
+
+		await fulfillment(of: [loadUrlExp], timeout: 1.0, enforceOrder: true)
+
+		XCTAssertEqual(response.clientId, "https://client-metadata.test/oauth-client-metadata.json")
+		XCTAssertEqual(response.scope, "atproto")
+		XCTAssertEqual(response.redirectURIs.isEmpty, false)
+		XCTAssertEqual(response.redirectURIs.first, "https://client-metadata.test/oauth/callback")
+	}
+
 	func testProtectedResourceMetadataLoad() async throws {
 		let loadUrlExp = expectation(description: "load url")
 

--- a/Tests/OAuthenticatorTests/WellKnownTests.swift
+++ b/Tests/OAuthenticatorTests/WellKnownTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import OAuthenticator
+
+final class WellKnownTests: XCTestCase {
+	func testProtectedResourceMetadataLoad() async throws {
+		let loadUrlExp = expectation(description: "load url")
+
+		let mockLoader: URLResponseProvider = { request in
+			XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+			loadUrlExp.fulfill()
+
+			let content = """
+				{"resource": "https://protected-resource-metadata.test"}
+				"""
+
+			let data = try XCTUnwrap(content.data(using: .utf8))
+
+			return (
+				data,
+				URLResponse(
+					url: request.url!,
+					mimeType: nil, expectedContentLength: data.count, textEncodingName: "utf-8")
+			)
+		}
+
+		let url = URL(string: "https://protected-resource-metadata.test/")!
+		let response = try await ProtectedResourceMetadata.load(
+			for: url.host!,
+			provider: mockLoader
+		)
+
+		await fulfillment(of: [loadUrlExp], timeout: 1.0, enforceOrder: true)
+
+		XCTAssertEqual(response.resource, "https://protected-resource-metadata.test")
+	}
+
+	func testProtectedResourceMetadataDecode() throws {
+		// Response from: https://puffball.us-east.host.bsky.network/.well-known/oauth-protected-resource/
+		let content = """
+			{"resource":"https://puffball.us-east.host.bsky.network","authorization_servers":["https://bsky.social"],"scopes_supported":[],"bearer_methods_supported":["header"],"resource_documentation":"https://atproto.com"}
+			"""
+		let data = try XCTUnwrap(content.data(using: .utf8))
+		let response = try XCTUnwrap(ProtectedResourceMetadata.loadJson(data: data))
+
+		XCTAssertEqual(response.resource, "https://puffball.us-east.host.bsky.network")
+		let authorizationServers = try XCTUnwrap(response.authorizationServers)
+		XCTAssertEqual(authorizationServers.isEmpty, false)
+		XCTAssertEqual(authorizationServers.first, "https://bsky.social")
+
+		let scopesSupported = try XCTUnwrap(response.scopesSupported)
+		XCTAssertEqual(scopesSupported.isEmpty, true)
+
+		let bearerMethodsSupported = try XCTUnwrap(response.bearerMethodsSupported)
+		XCTAssertEqual(bearerMethodsSupported.isEmpty, false)
+		XCTAssertEqual(bearerMethodsSupported.first, "header")
+
+		XCTAssertEqual(response.resourceDocumentation, "https://atproto.com")
+
+		// Missing fields
+		XCTAssertNil(response.authorizationDetailsTypesSupported)
+		XCTAssertNil(response.jwksUri)
+		XCTAssertNil(response.dpopBoundAccessTokensRequired)
+		XCTAssertNil(response.dpopSigningAlgValuesSupported)
+		XCTAssertNil(response.resourceName)
+		XCTAssertNil(response.resourcePolicyUri)
+		XCTAssertNil(response.resourceTosUri)
+		XCTAssertNil(response.signedMetadata)
+		XCTAssertNil(response.tlsClientCertificateBoundAccessTokens)
+	}
+}

--- a/Tests/OAuthenticatorTests/WellKnownTests.swift
+++ b/Tests/OAuthenticatorTests/WellKnownTests.swift
@@ -30,7 +30,7 @@ final class WellKnownTests: XCTestCase {
 					url: request.url!,
 					mimeType: "application/json",
 					expectedContentLength: data.count,
-					textEncodingName: nil
+					textEncodingName: "utf-8"
 				)
 			)
 		}
@@ -67,7 +67,7 @@ final class WellKnownTests: XCTestCase {
 					url: request.url!,
 					mimeType: "application/json",
 					expectedContentLength: data.count,
-					textEncodingName: nil
+					textEncodingName: "utf-8"
 				)
 			)
 		}
@@ -105,7 +105,8 @@ final class WellKnownTests: XCTestCase {
 					url: request.url!,
 					mimeType: "application/json",
 					expectedContentLength: data.count,
-					textEncodingName: nil)
+					textEncodingName: "utf-8"
+				)
 			)
 		}
 

--- a/Tests/OAuthenticatorTests/WellKnownTests.swift
+++ b/Tests/OAuthenticatorTests/WellKnownTests.swift
@@ -28,7 +28,10 @@ final class WellKnownTests: XCTestCase {
 				data,
 				URLResponse(
 					url: request.url!,
-					mimeType: nil, expectedContentLength: data.count, textEncodingName: "utf-8")
+					mimeType: "application/json",
+					expectedContentLength: data.count,
+					textEncodingName: nil
+				)
 			)
 		}
 
@@ -62,7 +65,10 @@ final class WellKnownTests: XCTestCase {
 				data,
 				URLResponse(
 					url: request.url!,
-					mimeType: nil, expectedContentLength: data.count, textEncodingName: "utf-8")
+					mimeType: "application/json",
+					expectedContentLength: data.count,
+					textEncodingName: nil
+				)
 			)
 		}
 
@@ -97,7 +103,9 @@ final class WellKnownTests: XCTestCase {
 				data,
 				URLResponse(
 					url: request.url!,
-					mimeType: nil, expectedContentLength: data.count, textEncodingName: "utf-8")
+					mimeType: "application/json",
+					expectedContentLength: data.count,
+					textEncodingName: nil)
 			)
 		}
 

--- a/Tests/OAuthenticatorTests/WellKnownTests.swift
+++ b/Tests/OAuthenticatorTests/WellKnownTests.swift
@@ -2,6 +2,10 @@ import XCTest
 
 @testable import OAuthenticator
 
+#if canImport(FoundationNetworking)
+	import FoundationNetworking
+#endif
+
 final class WellKnownTests: XCTestCase {
 	func testServerMetadataLoad() async throws {
 		let loadUrlExp = expectation(description: "load url")

--- a/Tests/OAuthenticatorTests/WellKnownTests.swift
+++ b/Tests/OAuthenticatorTests/WellKnownTests.swift
@@ -10,8 +10,16 @@ final class WellKnownTests: XCTestCase {
 			XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
 			loadUrlExp.fulfill()
 
+			// This is a more minimal Authorization Server Metadata that should be valid,
+			// but throws an error due to: https://github.com/ChimeHQ/OAuthenticator/issues/37
+			//
+			// let content = """
+			// 	{"issuer": "https://server-metadata.test", "authorization_endpoint": "https://server-metadata.test/oauth/authorize", "token_endpoint": "https://server-metadata.test/oauth/token"}
+			// 	"""
+
+			// Response from https://bsky.social/.well-known/oauth-authorization-server
 			let content = """
-				{"issuer": "https://server-metadata.test", "authorization_endpoint": "https://server-metadata.test/oauth/authorize", "token_endpoint": "https://server-metadata.test/oauth/token"}
+				{"issuer":"https://server-metadata.test","request_parameter_supported":true,"request_uri_parameter_supported":true,"require_request_uri_registration":true,"scopes_supported":["atproto","transition:email","transition:generic","transition:chat.bsky"],"subject_types_supported":["public"],"response_types_supported":["code"],"response_modes_supported":["query","fragment","form_post"],"grant_types_supported":["authorization_code","refresh_token"],"code_challenge_methods_supported":["S256"],"ui_locales_supported":["en-US"],"display_values_supported":["page","popup","touch"],"request_object_signing_alg_values_supported":["RS256","RS384","RS512","PS256","PS384","PS512","ES256","ES256K","ES384","ES512","none"],"authorization_response_iss_parameter_supported":true,"request_object_encryption_alg_values_supported":[],"request_object_encryption_enc_values_supported":[],"jwks_uri":"https://server-metadata.test/oauth/jwks","authorization_endpoint":"https://server-metadata.test/oauth/authorize","token_endpoint":"https://server-metadata.test/oauth/token","token_endpoint_auth_methods_supported":["none","private_key_jwt"],"token_endpoint_auth_signing_alg_values_supported":["RS256","RS384","RS512","PS256","PS384","PS512","ES256","ES256K","ES384","ES512"],"revocation_endpoint":"https://server-metadata.test/oauth/revoke","pushed_authorization_request_endpoint":"https://server-metadata.test/oauth/par","require_pushed_authorization_requests":true,"dpop_signing_alg_values_supported":["RS256","RS384","RS512","PS256","PS384","PS512","ES256","ES256K","ES384","ES512"],"client_id_metadata_document_supported":true}
 				"""
 
 			let data = try XCTUnwrap(content.data(using: .utf8))
@@ -45,7 +53,7 @@ final class WellKnownTests: XCTestCase {
 			loadUrlExp.fulfill()
 
 			let content = """
-				{"client_id": "https://client-metadata.test/oauth-client-metadata.json", "scope": "atproto", "redirect_uris": ["https://client-metadata.test/oauth/callback"]}
+				{"client_id": "https://client-metadata.test/oauth-client-metadata.json", "scope": "atproto", "redirect_uris": ["https://client-metadata.test/oauth/callback"], "dpop_bound_access_tokens": true}
 				"""
 
 			let data = try XCTUnwrap(content.data(using: .utf8))


### PR DESCRIPTION
The OAuth protected resource metadata is actually used during the Bluesky / AT Protocol authentication flow, which is:
1. resolve the handle to the DID
2. resolve the DID to the DID Document
3. fetch the OAuth Protected Resource Metadata for the `atproto_pds` service in the DID Document
4. fetch the OAuth Authorization Server Metadata for the authorization server indicated in the Protected Resource Metadata response
5. then the rest of the OAuth flow

This adds a struct similar to `ServerMetadata` for `ProtectedResourceMetadata`. I've also added test coverage.

Whilst I was adding the test coverage, I identified a bug where the `Accept` header was actually being sent via query parameter instead of request header. I've subsequently fixed that bug in `ServerMetadata`.

I've also added sending the `Accept` header to `ClientMetadata`, which is recommended by the CIMD internet draft (I'm the co-author)