### PR TITLE
Add clear method on login storage to prevent storing invalid tokens

### DIFF
--- a/Sources/OAuthenticator/Authenticator.swift
+++ b/Sources/OAuthenticator/Authenticator.swift
@@ -264,10 +264,8 @@ extension Authenticator {
 				await self.config.authenticationStatusHandler?(.success(login))
 		}
 		catch let authenticatorError as AuthenticatorError {
-				try await clearLogin()
-
 				await self.config.authenticationStatusHandler?(.failure(authenticatorError))
-				
+
 				// Rethrow error
 				throw authenticatorError
 		}
@@ -355,6 +353,8 @@ extension Authenticator {
 
 			return login
 		} catch {
+			try await clearLogin()
+
 			throw error
 		}
 	}

--- a/Sources/OAuthenticator/Models.swift
+++ b/Sources/OAuthenticator/Models.swift
@@ -88,13 +88,20 @@ public struct AppCredentials: Codable, Hashable, Sendable {
 public struct LoginStorage: Sendable {
 	public typealias RetrieveLogin = @Sendable () async throws -> Login?
 	public typealias StoreLogin = @Sendable (Login) async throws -> Void
+	public typealias ClearLogin = @Sendable () async throws -> Void
 
 	public let retrieveLogin: RetrieveLogin
 	public let storeLogin: StoreLogin
+	public let clearLogin: ClearLogin
 
-	public init(retrieveLogin: @escaping RetrieveLogin, storeLogin: @escaping StoreLogin) {
+	public init(
+		retrieveLogin: @escaping RetrieveLogin,
+		storeLogin: @escaping StoreLogin,
+		clearLogin: @escaping ClearLogin
+	) {
 		self.retrieveLogin = retrieveLogin
 		self.storeLogin = storeLogin
+		self.clearLogin = clearLogin
 	}
 }
 


### PR DESCRIPTION
This removes the "invalid login" that was previously being used, so is a breaking change, since it requires a new method be implemented in `loginStorage` (`clearLogin`). Perhaps we take this moment to also rename those methods to `clearSession` et' all.

Adding a `clearLogin` method seemed like the better option than making `storeLogin` accept a nil value as the `login` argument.

~~This is unfortunately based on #42~~