### PR TITLE
Return Login from manual authentication

### DIFF
--- a/Sources/OAuthenticator/Authenticator.swift
+++ b/Sources/OAuthenticator/Authenticator.swift
@@ -192,8 +192,12 @@ public actor Authenticator {
 	}
 
 	/// Manually perform user authentication, if required.
-	public func authenticate(with userAuthenticator: UserAuthenticator? = nil) async throws {
-		let _ = try await loginTaskResult(manual: true, userAuthenticator: userAuthenticator ?? config.userAuthenticator)
+	@discardableResult
+	public func authenticate(with userAuthenticator: UserAuthenticator? = nil) async throws -> Login {
+		return try await loginTaskResult(
+			manual: true,
+			userAuthenticator: userAuthenticator ?? config.userAuthenticator
+		)
 	}
 }
 


### PR DESCRIPTION
The `authenticate` call not returning the `Login` means that if you need to use the current session for something (e.g., performing another operation before storing the login in the place that other OAuthenticators access through `LoginStorage`), then you need to do a rather messy work around with `LoginStorage` to capture the session.

We do however already have the session here, we were just discarding it. This change returns the value, but marks it as a `discardableResult` — https://www.avanderlee.com/swift/discardableresult/