### PR TITLE
Run swift linux tests in docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'README.md'
-      - 'CODE_OF_CONDUCT.md'
-      - '.editorconfig'
-      - '.spi.yml'
+      - "README.md"
+      - "CODE_OF_CONDUCT.md"
+      - ".editorconfig"
+      - ".spi.yml"
   pull_request:
     branches:
       - main
@@ -40,20 +40,19 @@ jobs:
 
   linux_test:
     name: Test Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    container:
+      image: swift:${{matrix.swift-version}}
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         swift-version:
-          - 6.1
-          - 6.2
-          - latest
+          - "6.1"
+          - "6.2"
+          - "latest"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Swiftly
-        uses: vapor/swiftly-action@v0.2.0
-        with:
-          toolchain: ${{ matrix.swift-version }}
       - name: Test
         run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - run: swift --version
       - name: Test
         run: swift test


### PR DESCRIPTION
I was seeing too much instability in #50 with regards to the linux tests, due to the `vapor/swiftly-action` needing to install dependencies on ubuntu, which was randomly failing.

As a way to sidestep that issue, we can actually use the swift docker images to run these tests: https://hub.docker.com/_/swift/tags

This removes the need to install any ubuntu dependencies required to install swiftly, and gives a reproducible environment to run the tests in.