### PR TITLE
 Fix native macOS build by excluding SwiftUI WebAuthenticationSession

### DIFF
--- a/Sources/OAuthenticator/WebAuthenticationSession+Utility.swift
+++ b/Sources/OAuthenticator/WebAuthenticationSession+Utility.swift
@@ -1,9 +1,9 @@
-#if canImport(AuthenticationServices)
+#if canImport(AuthenticationServices) && !os(macOS)
 import AuthenticationServices
 import SwiftUI
 
 
-@available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *)
+@available(iOS 16.4, macCatalyst 16.4, watchOS 9.4, tvOS 16.4, *)
 extension WebAuthenticationSession {
 	public func userAuthenticator(preferredBrowserSession: BrowserSession? = nil) -> Authenticator.UserAuthenticator {
 		return {

--- a/Sources/OAuthenticator/WebAuthenticationSession+Utility.swift
+++ b/Sources/OAuthenticator/WebAuthenticationSession+Utility.swift
@@ -1,9 +1,11 @@
-#if canImport(AuthenticationServices) && !os(macOS)
-import AuthenticationServices
+// It is not 100% clear why a plain import of "AuthenticationServices" does not work here,
+// but in some cases/configuration it appears to fail.
+#if canImport(_AuthenticationServices_SwiftUI)
+import _AuthenticationServices_SwiftUI
 import SwiftUI
 
 
-@available(iOS 16.4, macCatalyst 16.4, watchOS 9.4, tvOS 16.4, *)
+@available(macOS 13.3, iOS 16.4, macCatalyst 16.4, watchOS 9.4, tvOS 16.4, *)
 extension WebAuthenticationSession {
 	public func userAuthenticator(preferredBrowserSession: BrowserSession? = nil) -> Authenticator.UserAuthenticator {
 		return {


### PR DESCRIPTION
`WebAuthenticationSession+Utility.swift` doesn't compile when building for
  **native macOS**, breaking `swift build` on a Mac and any SwiftPM consumer
  that resolves OAuthenticator for the macOS host.
  
  It builds no problem in Xcode but `swift build` fails.